### PR TITLE
Fixed utils.getArgs()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,8 +81,8 @@ module.exports = {
    * Pass in `arguments` to get back a proper Array
    * @returns {Array.<T>}
    */
-  getArgs: function() {
-    return Array.prototype.slice.call(arguments);
+  getArgs: function(args) {
+    return Array.prototype.slice.call(args);
   },
 
   /**


### PR DESCRIPTION
To not use it's own arguments object, but the one from the caller function that is being passed in :)