### PR TITLE
Customizable User-Agent

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,7 @@ module.exports = {
       headers: {}
     };
 
-    if (typeof client.config.useragent !== 'undefined') {
+    if (typeof client.config.userAgent !== 'undefined') {
       serverOptions.headers['User-Agent'] = client.config.userAgent;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,6 +37,10 @@ module.exports = {
       headers: {}
     };
 
+    if (typeof client.config.useragent !== 'undefined') {
+      serverOptions.headers['User-Agent'] = client.config.userAgent;
+    }
+
     serverOptions.headers['Content-Type'] = 'application/x-www-form-urlencoded';
     serverOptions.body = require('querystring').stringify(requestBody);
 

--- a/test/spec_helper.js
+++ b/test/spec_helper.js
@@ -4,7 +4,8 @@ var validConfig = {
   username: process.env.WHMCS_USER || 'username',
   password: process.env.WHMCS_KEY || 'password',
   apiKey: process.env.WHMCS_AK || 'accessKey',
-  serverUrl: process.env.WHMCS_URL || 'http://192.168.1.1/includes/api.php'
+  serverUrl: process.env.WHMCS_URL || 'http://192.168.1.1/includes/api.php',
+  userAgent: process.env.WHMCS_USERAGENT || 'node-whmcs'
 };
 
 module.exports = {


### PR DESCRIPTION
Some web servers are configured to drop requests with invalid or empty User-Agent headers. This allows you to optionally specify one via the config.