### PR TITLE
Prevent all ticket replies from being sent as admin user

### DIFF
--- a/modules/support.js
+++ b/modules/support.js
@@ -111,7 +111,7 @@ Support.prototype.replyTicket = function (ticketid, message, opts, callback) {
     options = extend(options, opts);
   }
 
-  if(!options.adminusername){
+  if(typeof options.adminusername === 'undefined' && typeof options.clientid === 'undefined'){
     options.adminusername = 'Auto-response';
   }
 


### PR DESCRIPTION
Even if you specify a `clientid` in the replyTicket options, the `adminusername` property is automatically populated (if empty). This results in the reply showing up as originating from an administrator, preventing you from using the API to post replies as/from clients. 

This should fix that by only overriding the `adminusername` property if:
- `adminusername` is not set
- no `clientid` has been provided